### PR TITLE
Checks if email is verified based on OpenID claim

### DIFF
--- a/lib/accounts-emails-field.js
+++ b/lib/accounts-emails-field.js
@@ -118,6 +118,11 @@ var getEmailsFromService = function(serviceName, service) {
 		else if (service.verified_email) {
 			verified = true;
 		}
+		// based on OpenID standard claims
+		// http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+		else if (service.email_verified) {
+			verified = service.email_verified;
+		}
 
 		return {
 			address: email.address,


### PR DESCRIPTION
Hello @splendido and congrats for the nice work.

This PR adds an extra check for when email is verified which covers Providers that are OpenID compliant. Based on the [OpenID spec](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) the OpenID claim is `email_verified`.
